### PR TITLE
Copy object multipart

### DIFF
--- a/tests/botocore.py
+++ b/tests/botocore.py
@@ -68,18 +68,18 @@ class BotocoreTest(unittest.TestCase):
         meta = response['ResponseMetadata']
         self.assertEqual(meta['HTTPStatusCode'], code)
 
-    def clean_up(self, r):
+    def clean_up(self, key, size):
         response = self.s3.head_object(Bucket=BUCKET,
-                                       Key=r.key)
+                                       Key=key)
         self.assert_status(response)
-        self.assertEqual(response['ContentLength'], r.size)
+        self.assertEqual(response['ContentLength'], size)
         # Delete
         response = self.s3.delete_object(Bucket=BUCKET,
-                                         Key=r.key)
+                                         Key=key)
         self.assert_status(response, 204)
         self.assertRaises(ClientError, self.s3.get_object,
                           Bucket=BUCKET,
-                          Key=r.key)
+                          Key=key)
 
     # TESTS
     def test_describe_instances(self):
@@ -140,7 +140,7 @@ class BotocoreTest(unittest.TestCase):
             response = self.s3.upload_file(BUCKET,
                                            r.filename)
             self.assert_status(response)
-            self.clean_up(r)
+            self.clean_up(r.key, r.size)
 
     @green
     def test_upload_binary_large(self):
@@ -148,4 +148,30 @@ class BotocoreTest(unittest.TestCase):
             response = self.s3.upload_file(BUCKET,
                                            r.filename)
             self.assert_status(response)
-            self.clean_up(r)
+            self.clean_up(r.key, r.size)
+
+    @green
+    def test_copy(self):
+        self._test_copy(2**12)
+
+    @green
+    def test_copy_large(self):
+        self._test_copy(1.5*MULTI_PART_SIZE)
+
+    def _test_copy(self, size):
+        with RandomFile(int(size)) as r:
+            response = self.s3.upload_file(BUCKET, r.filename)
+            self.assert_status(response)
+            copy_key = 'copy_{}'.format(r.key)
+            response = self.s3.copy_storage_object(
+                BUCKET, r.key, BUCKET, copy_key)
+            self.assert_status(response)
+            self.assert_s3_equal(r.filename, copy_key)
+            self.clean_up(r.key, r.size)
+            self.clean_up(copy_key, r.size)
+
+    def assert_s3_equal(self, filename, copy_name):
+        response = self.s3.get_object(Bucket=BUCKET, Key=copy_name)
+        with open(filename, 'rb') as fo:
+            body = b''.join(self.s3.wsgi_stream_body(response['Body']))
+            self.assertEqual(body, fo.read())


### PR DESCRIPTION
Transparently do multipart copy.

One note: The current default MULTI_PART_SIZE (as also used by upload) restricts file to be a maximum of 78GB as you can only do 10.000 parts, while S3 supports 5TB, it might be a good idea to change that.
